### PR TITLE
Issue #17: add role-repo marker rollout evidence links

### DIFF
--- a/00-os/governed-repos.yml
+++ b/00-os/governed-repos.yml
@@ -32,7 +32,9 @@ repositories:
     owner_role: "AI Governance Manager"
     marker_path: ".context-engineering/governance.yml"
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17."
+    marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-compliance-officer/pull/6"
+    control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
+    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
 
   - repo: "Josh-Phillips-LLC/context-engineering-role-hr-ai-agent-specialist"
     family: "context-engineering-role-repos"
@@ -40,7 +42,9 @@ repositories:
     owner_role: "AI Governance Manager"
     marker_path: ".context-engineering/governance.yml"
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17."
+    marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-hr-ai-agent-specialist/pull/6"
+    control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
+    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
 
   - repo: "Josh-Phillips-LLC/context-engineering-role-implementation-specialist"
     family: "context-engineering-role-repos"
@@ -48,7 +52,9 @@ repositories:
     owner_role: "AI Governance Manager"
     marker_path: ".context-engineering/governance.yml"
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17."
+    marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-implementation-specialist/pull/3"
+    control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
+    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
 
   - repo: "Josh-Phillips-LLC/context-engineering-role-systems-architect"
     family: "context-engineering-role-repos"
@@ -56,7 +62,9 @@ repositories:
     owner_role: "AI Governance Manager"
     marker_path: ".context-engineering/governance.yml"
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17."
+    marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect/pull/3"
+    control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
+    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
 
   - repo: "Josh-Phillips-LLC/JoshGPT-MCP"
     family: "joshgpt-platform-repos"


### PR DESCRIPTION
## Summary
- update role repo entries in `00-os/governed-repos.yml` with marker PR evidence links
- link unresolved transition control gaps to Context-Engineering issue #28
- keep all role repos in `transition` pending governed-gate evidence

## Validation
- `python3 00-os/scripts/validate-governance-ownership.py`

## Machine-Readable Metadata (Required)
Primary-Role: Systems Architect
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Required

## Protected Change Note
- This PR touches `00-os/governed-repos.yml` (protected path), so explicit Executive Sponsor approval is required before merge.

Closes #17
