### PR TITLE
Issue #28: record role-repo transition control evidence

### DIFF
--- a/00-os/governed-repos.yml
+++ b/00-os/governed-repos.yml
@@ -34,7 +34,8 @@ repositories:
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
     marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-compliance-officer/pull/6"
     control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
+    transition_controls_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-compliance-officer/pull/8"
+    notes: "Role-governance marker and transition controls are applied; governed promotion remains pending governed-gate evidence."
 
   - repo: "Josh-Phillips-LLC/context-engineering-role-hr-ai-agent-specialist"
     family: "context-engineering-role-repos"
@@ -44,7 +45,8 @@ repositories:
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
     marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-hr-ai-agent-specialist/pull/6"
     control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
+    transition_controls_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-hr-ai-agent-specialist/pull/7"
+    notes: "Role-governance marker and transition controls are applied; governed promotion remains pending governed-gate evidence."
 
   - repo: "Josh-Phillips-LLC/context-engineering-role-implementation-specialist"
     family: "context-engineering-role-repos"
@@ -54,7 +56,8 @@ repositories:
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
     marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-implementation-specialist/pull/3"
     control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
+    transition_controls_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-implementation-specialist/pull/4"
+    notes: "Role-governance marker and transition controls are applied; governed promotion remains pending governed-gate evidence."
 
   - repo: "Josh-Phillips-LLC/context-engineering-role-systems-architect"
     family: "context-engineering-role-repos"
@@ -64,7 +67,8 @@ repositories:
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/17"
     marker_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect/pull/3"
     control_gap_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/28"
-    notes: "Role-governance controls exist; marker rollout tracked in Issue #17 with control gaps in Issue #28."
+    transition_controls_pr: "https://github.com/Josh-Phillips-LLC/context-engineering-role-systems-architect/pull/4"
+    notes: "Role-governance marker and transition controls are applied; governed promotion remains pending governed-gate evidence."
 
   - repo: "Josh-Phillips-LLC/JoshGPT-MCP"
     family: "joshgpt-platform-repos"


### PR DESCRIPTION
## Summary
- add transition control evidence links for role repos in `00-os/governed-repos.yml`
- record merged transition-controls PRs for all role repos
- keep role repos in `transition` state pending future governed-gate promotion

## Validation
- `python3 00-os/scripts/validate-governance-ownership.py`

## Machine-Readable Metadata (Required)
Primary-Role: Systems Architect
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Provided

## Protected Change Note
- This PR touches `00-os/governed-repos.yml` (protected path).

Closes #28
