### PR TITLE
Issue #20: record mcp-auth-broker transition evidence

### DIFF
--- a/00-os/governed-repos.yml
+++ b/00-os/governed-repos.yml
@@ -92,4 +92,6 @@ repositories:
     owner_role: "AI Governance Manager"
     marker_path: ".context-engineering/governance.yml"
     rollout_issue: "https://github.com/Josh-Phillips-LLC/Context-Engineering/issues/20"
-    notes: "Governance onboarding in progress and tracked in Issue #20."
+    marker_pr: "https://github.com/Josh-Phillips-LLC/mcp-auth-broker/pull/10"
+    transition_controls_pr: "https://github.com/Josh-Phillips-LLC/mcp-auth-broker/pull/10"
+    notes: "Governance onboarding baseline is applied with transition controls; governed promotion remains pending governed-gate evidence."


### PR DESCRIPTION
## Summary
- update `00-os/governed-repos.yml` with `mcp-auth-broker` transition-state evidence links
- record merged marker/control baseline PR for onboarding issue #20
- keep repo state at `transition` pending governed-gate promotion evidence

## Validation
- `python3 00-os/scripts/validate-governance-ownership.py`

## Machine-Readable Metadata (Required)
Primary-Role: Systems Architect
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Provided

## Protected Change Note
- This PR touches `00-os/governed-repos.yml` (protected path).

Closes #20
