### PR TITLE
[Implementation Specialist] Define canonical ADR schema and lifecycle (#66)

### DIFF
--- a/00-os/adr/README.md
+++ b/00-os/adr/README.md
@@ -1,0 +1,114 @@
+# ADR Schema and Lifecycle (Normative)
+
+This document defines the canonical Architecture Decision Record (ADR) schema and lifecycle for Context-Engineering.
+
+This specification is normative for issue #66.
+
+## 1. Canonical Location and Naming
+
+- ADR files MUST live under `00-os/adr/`.
+- ADR filename MUST match: `^\d{4}-[a-z0-9-]+\.md$`.
+- ADR ID MUST be a zero-padded 4-digit number: `^\d{4}$`.
+- ADR file prefix MUST equal `ADR-ID` (for example, `0007-...` MUST contain `ADR-ID: 0007`).
+- Each ADR file MUST represent one decision.
+- ADR IDs are immutable and MUST NOT be reused.
+
+## 2. Required Metadata Keys
+
+Each ADR MUST include the following metadata keys exactly once using `Key: Value` format:
+
+- `ADR-ID: <4-digit>`
+- `Title: <short decision title>`
+- `Status: Draft|Proposed|Accepted|Superseded|Deprecated`
+- `Date: YYYY-MM-DD`
+- `Decision-Owners: <role list>`
+- `Approvers: <role list>`
+- `Supersedes: <ADR-ID>|N/A`
+- `Superseded-By: <ADR-ID>|N/A`
+
+Format rules:
+
+- `Status` MUST use one of the allowed enum values exactly.
+- `Date` MUST match `YYYY-MM-DD`.
+- `Supersedes` and `Superseded-By` MUST be either a valid ADR ID or `N/A`.
+
+## 3. Required Sections
+
+Each ADR MUST include the following headings exactly once:
+
+1. `## Context`
+2. `## Decision`
+3. `## Consequences`
+4. `## Alternatives Considered`
+5. `## References`
+
+## 4. Lifecycle Model
+
+Allowed transitions:
+
+- `Draft -> Proposed`
+- `Proposed -> Accepted`
+- `Proposed -> Deprecated`
+- `Accepted -> Superseded`
+- `Accepted -> Deprecated`
+
+Disallowed examples:
+
+- `Accepted -> Proposed`
+- `Superseded -> Accepted`
+- `Deprecated -> Accepted`
+
+State semantics:
+
+- `Draft`: working record, not ready for approval.
+- `Proposed`: review-ready candidate decision.
+- `Accepted`: approved active decision.
+- `Superseded`: replaced by a newer accepted ADR.
+- `Deprecated`: intentionally retired without direct replacement.
+
+`Superseded` and `Deprecated` are terminal states.
+
+## 5. Approval and Authority Matrix
+
+- Compliance Officer review is required for ADR conformance and traceability.
+- Executive Sponsor approval is required before merge for ADRs with `Status: Accepted` that affect protected paths or the operating model.
+- Superseding decisions require reciprocal supersession fields (`Supersedes` and `Superseded-By`) before merge.
+
+Current repository note:
+
+- ADR files are stored under `00-os/adr/`.
+- `00-os/` is a protected path under current governance.
+- Therefore, ADR changes that establish or modify accepted operating-model decisions are treated as protected changes.
+
+## 6. Supersession Rules (Reciprocal)
+
+When ADR `NNNN` supersedes ADR `MMMM`:
+
+- New ADR MUST set `Supersedes: MMMM`.
+- Prior ADR `MMMM` MUST be updated to set `Superseded-By: NNNN`.
+- Self-supersession is invalid.
+- Supersession targets MUST exist.
+
+## 7. Machine-Checkable Validation Contract
+
+The ADR validator (issue #68) MUST be able to check at minimum:
+
+- Path and filename constraints (`00-os/adr/`, filename regex).
+- Metadata key presence and uniqueness.
+- Metadata format/enum validity.
+- `ADR-ID` to filename prefix match.
+- Required heading presence and uniqueness.
+- Supersession target existence and reciprocal-link consistency.
+- Lifecycle transition validity (when transition-check mode is enabled).
+
+Recommended rule IDs for deterministic output:
+
+- `ADR001`: invalid path/location
+- `ADR002`: invalid filename pattern
+- `ADR003`: missing/duplicate required metadata
+- `ADR004`: invalid metadata enum/format
+- `ADR005`: missing/duplicate required heading
+- `ADR006`: ADR-ID and filename mismatch
+- `ADR007`: supersession target missing/invalid
+- `ADR008`: reciprocal supersession mismatch
+- `ADR009`: invalid status transition


### PR DESCRIPTION
# Summary
- Add canonical ADR schema and lifecycle specification at `00-os/adr/README.md`.
- Define exact path/naming rules, required metadata keys/headings, status enum/transitions, approval matrix, and reciprocal supersession rules.
- Define machine-checkable validation contract to scope deterministic validator implementation in #68.

# Issue
- Linked issue (primary tracked issue): #66
- Primary-Issue-Ref: Closes #66
- Additional issue references (optional):

# Issue Linkage (Outcome-Based, Required)
- [x] Exactly one primary tracked issue is declared using `Primary-Issue-Ref: Closes #<ISSUE_NUMBER>` or `Primary-Issue-Ref: Refs #<ISSUE_NUMBER>`
- [x] Primary issue shows this PR in GitHub Development before merge, or an explicit exception with compensating evidence is documented
- [x] `gh issue develop <ISSUE_NUMBER> --checkout` was used where practical (recommended, not mandatory)

# Development Linkage Evidence (Required)
- Development-Linkage: Verified
- Development-Linkage-Evidence: Issue #66 Development section links this PR.

# Machine-Readable Metadata (Required)
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Required

# Scope Control
- In-scope for #66 only (schema/lifecycle definition).
- No ADR template authoring changes (#67), validator implementation (#68), or governance/checklist integration updates (#69).

# Acceptance Mapping (#66)
- [x] Canonical ADR location and naming are defined (`00-os/adr/`, `^\d{4}-[a-z0-9-]+\.md$`).
- [x] Required metadata keys are defined with exact names and allowed formats.
- [x] Required section headings are defined with exact names.
- [x] Status enum is finalized (`Draft|Proposed|Accepted|Superseded|Deprecated`).
- [x] Allowed/disallowed lifecycle transitions are explicitly documented.
- [x] Approval matrix defines when Executive Sponsor approval is required for `Accepted` ADRs.
- [x] Supersession rules are explicit and reciprocal (`Supersedes` / `Superseded-By`).
- [x] Criteria are machine-checkable by validator scope in #68.
