### PR TITLE
[Implementation Specialist] Publish ADR template and authoring guide (#67)

### DIFF
--- a/00-os/adr/0000-template.md
+++ b/00-os/adr/0000-template.md
@@ -1,0 +1,27 @@
+ADR-ID: 0000
+Title: <decision-title>
+Status: Draft
+Date: YYYY-MM-DD
+Decision-Owners: <role(s)>
+Approvers: <role(s)>
+Supersedes: N/A
+Superseded-By: N/A
+
+## Context
+<What problem or constraint exists now?>
+
+## Decision
+<What is decided, exactly?>
+
+## Consequences
+- Positive:
+- Negative / Trade-offs:
+
+## Alternatives Considered
+1. <Alternative A> - <why not chosen>
+2. <Alternative B> - <why not chosen>
+
+## References
+- Primary Issue: #<number>
+- Primary PR: #<number>
+- Related ADR(s): <ADR-ID list or N/A>

--- a/00-os/adr/0001-record-architecture-decisions.md
+++ b/00-os/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,34 @@
+ADR-ID: 0001
+Title: Record architecture decisions using ADRs
+Status: Proposed
+Date: 2026-02-26
+Decision-Owners: AI Governance Manager, Compliance Officer
+Approvers: Executive Sponsor
+Supersedes: N/A
+Superseded-By: N/A
+
+## Context
+Context-Engineering governance and implementation work spans multiple repositories and role agents. Decision rationale has often been distributed across issue and PR threads, which weakens deterministic traceability for compliance and change-control reviews.
+
+## Decision
+Adopt Architecture Decision Records (ADRs) under `00-os/adr/` using canonical schema, lifecycle, naming, and supersession rules.
+
+ADRs become the durable source of truth for architecture-level decisions. Issues and PRs remain execution and evidence artifacts that reference ADRs.
+
+## Consequences
+- Positive:
+  - Deterministic decision history with clear authority and approval signals.
+  - Stronger traceability: ADR -> issue -> PR.
+  - Cleaner governance/compliance review for protected changes.
+- Negative / Trade-offs:
+  - Additional authoring and review overhead.
+  - Requires validation tooling and contributor onboarding.
+
+## Alternatives Considered
+1. Keep architecture decisions only in issue/PR prose - rejected due to weak long-term traceability.
+2. Use free-form decision notes without strict schema - rejected due to non-deterministic reviewability.
+
+## References
+- Primary Issue: #64
+- Primary PR: N/A
+- Related ADR(s): N/A

--- a/00-os/adr/AUTHORING.md
+++ b/00-os/adr/AUTHORING.md
@@ -1,0 +1,52 @@
+# ADR Authoring Guide
+
+This guide explains how to author ADRs using the canonical schema defined in `00-os/adr/README.md`.
+
+## 1. Path, Naming, and Numbering
+
+- Store ADR files in `00-os/adr/`.
+- Use filename format: `<ADR-ID>-<kebab-case-title>.md`.
+- Use zero-padded 4-digit IDs: `0001`, `0002`, `0003`, ...
+- One ADR file = one decision.
+- ADR IDs are immutable and never reused.
+
+## 2. New ADR Flow (Non-Superseding)
+
+1. Copy `00-os/adr/0000-template.md` to the next ADR ID filename.
+2. Fill all required metadata keys and required sections.
+3. Set initial status to `Draft` while iterating.
+4. Promote to `Proposed` when opening review PR.
+5. Move to `Accepted` only when required approvals are present.
+
+## 3. PR Issue-Linkage (`Closes` vs `Refs`)
+
+When opening a PR that introduces or updates ADR content:
+
+- Use `Primary-Issue-Ref: Closes #<ISSUE_NUMBER>` when the PR fully satisfies that issue's definition of done.
+- Use `Primary-Issue-Ref: Refs #<ISSUE_NUMBER>` when the PR is partial, dependency work, or otherwise non-closing.
+
+Keep exactly one primary issue reference in the PR body, and include Development-linkage evidence per repo workflow.
+
+## 4. Superseding ADR Flow
+
+When replacing an accepted ADR decision:
+
+1. Create a new ADR with a new ID.
+2. In the new ADR, set `Supersedes: <OLD_ID>`.
+3. In the old ADR, set `Superseded-By: <NEW_ID>`.
+4. Update status of old ADR to `Superseded`.
+5. Ensure reciprocal links are merged together to maintain traceability.
+
+## 5. Minimal Migration Guidance (Pre-ADR Decisions)
+
+For historical architecture decisions recorded only in issues/PRs:
+
+1. Create a new ADR that captures the decision and rationale.
+2. Link legacy issue/PR artifacts in `## References`.
+3. Mark unknown supersession values as `N/A` until formally superseded.
+4. Do not rewrite historical issue/PR content; add traceability forward via ADR references.
+
+## 6. Role and Approval Notes
+
+- Compliance Officer review is required for ADR conformance.
+- Executive Sponsor approval is required before merge when ADR status/impact triggers protected-change gates.

--- a/00-os/adr/README.md
+++ b/00-os/adr/README.md
@@ -4,6 +4,12 @@ This document defines the canonical Architecture Decision Record (ADR) schema an
 
 This specification is normative for issue #66.
 
+## Related ADR Authoring Artifacts
+
+- Template: `00-os/adr/0000-template.md`
+- Starter ADR: `00-os/adr/0001-record-architecture-decisions.md`
+- Authoring guide: `00-os/adr/AUTHORING.md`
+
 ## 1. Canonical Location and Naming
 
 - ADR files MUST live under `00-os/adr/`.

--- a/00-os/workflow.md
+++ b/00-os/workflow.md
@@ -35,6 +35,7 @@
 - Prefer templates and checklists over prose.
 - Add TODOs when judgment is required.
 - Keep Plane A/Plane B separation intact.
+- For architecture decisions, use ADR artifacts in `00-os/adr/` and follow `00-os/adr/AUTHORING.md`.
 
 ## Artifact Flow
 - Session Canvas → Publishable Extract → Repo Canvas

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,12 @@ Thanks for helping improve Context-Engineering. Please keep changes scoped and r
 4. Open a PR that declares the primary Issue with `Closes #<ISSUE_NUMBER>` or `Refs #<ISSUE_NUMBER>` and includes required role metadata.
 5. Ensure the primary Issue shows PR linkage in GitHub Development before merge (or document an explicit exception with compensating evidence in the PR).
 
+## Architecture Decisions (ADR)
+
+- Author architecture-level decisions under `00-os/adr/`.
+- Use the ADR template at `00-os/adr/0000-template.md`.
+- Follow authoring guidance at `00-os/adr/AUTHORING.md`.
+
 ## Safety and Scope
 
 - Do not include secrets, tokens, credentials, PII, or internal hostnames.

--- a/governance.md
+++ b/governance.md
@@ -201,6 +201,8 @@ All meaningful changes in this repo should be **reviewable**. The default workfl
 - Reduce “random walk” documentation
 - Provide a clear contract between agents and reviewers
 
+For architecture-level decisions, use ADR artifacts under `00-os/adr/` and the authoring guide at `00-os/adr/AUTHORING.md`.
+
 ### Default workflow
 1. **Create an Issue** (Executive Sponsor, AI Governance Manager, Business Analyst, or Implementation Specialist) defining: objective, scope, constraints, and definition of done
 2. **Create a branch and link it to the primary Issue** using any valid GitHub path that preserves deterministic linkage (recommended: `gh issue develop <ISSUE_NUMBER> --checkout`) (role occupant)


### PR DESCRIPTION
# Summary
- Publish official ADR template (`00-os/adr/0000-template.md`).
- Add starter ADR draft (`00-os/adr/0001-record-architecture-decisions.md`).
- Add ADR authoring guide (`00-os/adr/AUTHORING.md`) covering naming/numbering/path rules, new ADR flow, superseding ADR flow, and minimal migration guidance.
- Link ADR guidance from contributor/workflow touchpoints.

# Issue
- Linked issue (primary tracked issue): #67
- Primary-Issue-Ref: Closes #67
- Additional issue references (optional):

# Issue Linkage (Outcome-Based, Required)
- [x] Exactly one primary tracked issue is declared using `Primary-Issue-Ref: Closes #<ISSUE_NUMBER>` or `Primary-Issue-Ref: Refs #<ISSUE_NUMBER>`
- [x] Primary issue shows this PR in GitHub Development before merge, or an explicit exception with compensating evidence is documented
- [x] `gh issue develop <ISSUE_NUMBER> --checkout` was used where practical (recommended, not mandatory)

# Development Linkage Evidence (Required)
- Development-Linkage: Verified
- Development-Linkage-Evidence: Issue #67 Development section links this PR.

# Machine-Readable Metadata (Required)
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Required

# Scope Control
- In-scope for #67 only (template, starter ADR, authoring guide, and touchpoint links).
- No ADR validator implementation changes from #68.
- No governance/checklist enforcement integration from #69.

# Acceptance Mapping (#67)
- [x] ADR template exists with required metadata keys and required sections.
- [x] Template includes status and supersession fields.
- [x] Authoring guide documents path, naming, numbering, and one-decision-per-file rule.
- [x] Authoring guide includes new ADR flow and superseding ADR flow examples.
- [x] Starter ADR draft exists (`0001-record-architecture-decisions.md`).
- [x] Guidance is linked from governance/workflow contributor touchpoints.
