### PR TITLE
Implementation Specialist: Add PR metadata validator tests (Issue #88)

### DIFF
--- a/.github/workflows/validate-role-wiring.yml
+++ b/.github/workflows/validate-role-wiring.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 00-os/role-registry.yml
       - 00-os/scripts/generate-role-wiring.py
-      - 00-os/scripts/tests/test_generate_role_wiring.py
+      - 00-os/scripts/tests/test_*.py
       - .github/workflows/sync-role-repos.yml
       - .github/workflows/publish-role-workstation-images.yml
       - .devcontainer-workstation/docker-compose.yml
@@ -17,7 +17,7 @@ on:
     paths:
       - 00-os/role-registry.yml
       - 00-os/scripts/generate-role-wiring.py
-      - 00-os/scripts/tests/test_generate_role_wiring.py
+      - 00-os/scripts/tests/test_*.py
       - .github/workflows/sync-role-repos.yml
       - .github/workflows/publish-role-workstation-images.yml
       - .devcontainer-workstation/docker-compose.yml

--- a/00-os/scripts/tests/test_validate_pr_metadata.py
+++ b/00-os/scripts/tests/test_validate_pr_metadata.py
@@ -1,0 +1,129 @@
+"""Unit tests for PR metadata validation logic."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "validate-pr-metadata.py"
+SPEC = importlib.util.spec_from_file_location("validate_pr_metadata", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+SAMPLE_DIR = Path(__file__).resolve().parents[1] / "pr-metadata-samples"
+
+
+def make_body(
+    *,
+    primary_role: str = "Implementation Specialist",
+    reviewed_by_role: str = "Compliance Officer",
+    executive_sponsor_approval: str = "Not-Required",
+    primary_issue_ref: str = "Closes #88",
+    development_linkage: str = "Exception",
+    development_linkage_evidence: str = "Linked issue and PR timeline evidence.",
+) -> str:
+    return "\n".join(
+        [
+            f"Primary-Role: {primary_role}",
+            f"Reviewed-By-Role: {reviewed_by_role}",
+            f"Executive-Sponsor-Approval: {executive_sponsor_approval}",
+            f"Primary-Issue-Ref: {primary_issue_ref}",
+            f"Development-Linkage: {development_linkage}",
+            f"Development-Linkage-Evidence: {development_linkage_evidence}",
+        ]
+    )
+
+
+class ParsePrimaryIssueRefTests(unittest.TestCase):
+    def test_parses_closes_issue_reference(self):
+        self.assertEqual(MODULE.parse_primary_issue_ref("Closes #88"), ("Closes", 88))
+
+    def test_parses_refs_issue_reference(self):
+        self.assertEqual(MODULE.parse_primary_issue_ref("Refs #190"), ("Refs", 190))
+
+    def test_rejects_invalid_issue_reference_format(self):
+        self.assertIsNone(MODULE.parse_primary_issue_ref("Closes 88"))
+
+
+class ValidateMetadataTests(unittest.TestCase):
+    def test_missing_required_role_fields_fails(self):
+        body = "\n".join(
+            [
+                "Reviewed-By-Role: Compliance Officer",
+                "Executive-Sponsor-Approval: Not-Required",
+                "Primary-Issue-Ref: Closes #88",
+                "Development-Linkage: Exception",
+                "Development-Linkage-Evidence: linked",
+            ]
+        )
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertIn(
+            "Missing required PR metadata field 'Primary-Role' or empty value.",
+            errors,
+        )
+
+    def test_invalid_primary_role_value_fails(self):
+        body = make_body(primary_role="Reviewer")
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertIn(
+            "Invalid value for 'Primary-Role': 'Reviewer'. Allowed: Executive Sponsor | AI Governance Manager | Compliance Officer | Business Analyst | Implementation Specialist | Systems Architect.",
+            errors,
+        )
+
+    def test_invalid_primary_issue_ref_format_fails(self):
+        body = make_body(primary_issue_ref="Close #88")
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertIn(
+            "Invalid 'Primary-Issue-Ref' format. Use exactly one value in the form 'Closes #<ISSUE_NUMBER>' or 'Refs #<ISSUE_NUMBER>'.",
+            errors,
+        )
+
+    def test_duplicate_primary_issue_ref_fails(self):
+        body = make_body() + "\nPrimary-Issue-Ref: Refs #77"
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertIn(
+            "Expected exactly one 'Primary-Issue-Ref' field; found 2.",
+            errors,
+        )
+
+    def test_missing_development_linkage_fails(self):
+        body = "\n".join(
+            [
+                "Primary-Role: Implementation Specialist",
+                "Reviewed-By-Role: Compliance Officer",
+                "Executive-Sponsor-Approval: Not-Required",
+                "Primary-Issue-Ref: Closes #88",
+                "Development-Linkage-Evidence: linked",
+            ]
+        )
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertIn(
+            "Missing required field 'Development-Linkage'. Set it to 'Verified' or 'Exception'.",
+            errors,
+        )
+
+    def test_invalid_development_linkage_value_fails(self):
+        body = make_body(development_linkage="Unknown")
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertIn(
+            "Invalid 'Development-Linkage' value. Allowed: Verified | Exception.",
+            errors,
+        )
+
+    def test_missing_development_linkage_evidence_fails(self):
+        body = make_body() + "\nDevelopment-Linkage-Evidence:"
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertIn(
+            "Expected exactly one 'Development-Linkage-Evidence' field; found 2.",
+            errors,
+        )
+
+    def test_valid_sample_body_passes(self):
+        body = (SAMPLE_DIR / "valid-gh-issue-develop.md").read_text(encoding="utf-8")
+        errors = MODULE.validate(body=body, repo=None, pr_number=None, github_token=None)
+        self.assertEqual([], errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary
- Add unit tests for `00-os/scripts/validate-pr-metadata.py` covering required fields, enum validation, issue-reference parsing, development-linkage validation, and valid sample success path.
- Expand `.github/workflows/validate-role-wiring.yml` path filters from one fixed test file to `00-os/scripts/tests/test_*.py` so new test modules in the same suite trigger CI.
- Local verification:
  - `python3 -m unittest discover -s 00-os/scripts/tests -p 'test_*.py'` (pass)
  - `python3 00-os/scripts/validate-pr-metadata.py --input-file 00-os/scripts/pr-metadata-samples/valid-gh-issue-develop.md` (pass)

# Issue
- Linked issue (primary tracked issue):
- Primary-Issue-Ref: Closes #88

# Development Linkage Evidence (Required)
- Development-Linkage: Verified
- Development-Linkage-Evidence: Issue #88 Development section links this PR.

# ADR Linkage (Required for architecture/protected changes)
- ADR-Required: No
- Primary-ADR: 0004-calibrate-adr-trigger-policy-for-decision-level-vs-implementation-only-changes.md
- ADR-Status-At-Merge: Accepted
- ADR-Implementation-Rationale: Implementation-only quality hardening for existing PR metadata governance checks; no new decision-level architecture/process change.
- ADR-Exception-Evidence: N/A
- ADR-Supersession-Traceability: N/A

# Machine-Readable Metadata (Required)
Primary-Role: Implementation Specialist
Reviewed-By-Role: Compliance Officer
Executive-Sponsor-Approval: Required
