### PR TITLE
[Split Phase 2] Restrict legacy execution workflows to emergency fallback

### DIFF
--- a/.github/workflows/orchestrate-role-onboarding.yml
+++ b/.github/workflows/orchestrate-role-onboarding.yml
@@ -3,6 +3,22 @@ name: Orchestrate Role Onboarding
 on:
   workflow_dispatch:
     inputs:
+      legacy_fallback_ack:
+        description: 'Type ALLOW-LEGACY-FALLBACK to authorize emergency legacy onboarding'
+        required: true
+        type: string
+      approval_issue_url:
+        description: 'Context-Engineering Issue URL approving emergency fallback use'
+        required: true
+        type: string
+      approval_comment_url:
+        description: 'Approval comment URL (Executive Sponsor or delegated approver)'
+        required: true
+        type: string
+      emergency_reason:
+        description: 'Short reason why implementation repo onboarding path cannot be used'
+        required: true
+        type: string
       role_slug:
         description: 'Role slug (e.g., implementation-specialist)'
         required: true
@@ -31,10 +47,43 @@ permissions:
   contents: read
 
 jobs:
+  authorize_fallback:
+    name: Authorize Legacy Fallback
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.authorize.outputs.approved }}
+    steps:
+      - name: Validate emergency fallback authorization
+        id: authorize
+        env:
+          ACK: ${{ inputs.legacy_fallback_ack }}
+          ISSUE_URL: ${{ inputs.approval_issue_url }}
+          COMMENT_URL: ${{ inputs.approval_comment_url }}
+          REASON: ${{ inputs.emergency_reason }}
+        run: |
+          set -euo pipefail
+          if [ "$ACK" != "ALLOW-LEGACY-FALLBACK" ]; then
+            echo "::error::Legacy fallback authorization denied. Set legacy_fallback_ack to ALLOW-LEGACY-FALLBACK."
+            exit 1
+          fi
+          if [ -z "$ISSUE_URL" ] || [ -z "$COMMENT_URL" ] || [ -z "$REASON" ]; then
+            echo "::error::approval_issue_url, approval_comment_url, and emergency_reason are required."
+            exit 1
+          fi
+          {
+            echo "### Legacy fallback authorization"
+            echo
+            echo "- Approval issue: \`$ISSUE_URL\`"
+            echo "- Approval comment: \`$COMMENT_URL\`"
+            echo "- Reason: \`$REASON\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "approved=true" >> "$GITHUB_OUTPUT"
+
   preflight:
     name: Preflight Validation
     runs-on: ubuntu-latest
-    if: ${{ !inputs.skip_validation }}
+    needs: [authorize_fallback]
+    if: ${{ needs.authorize_fallback.outputs.approved == 'true' && !inputs.skip_validation }}
     outputs:
       validation_passed: ${{ steps.validate.outputs.passed }}
     steps:
@@ -83,8 +132,8 @@ jobs:
   sync:
     name: Sync Role Repository
     runs-on: ubuntu-latest
-    needs: [preflight]
-    if: ${{ always() && (needs.preflight.result == 'success' || inputs.skip_validation) }}
+    needs: [authorize_fallback, preflight]
+    if: ${{ always() && needs.authorize_fallback.outputs.approved == 'true' && (needs.preflight.result == 'success' || inputs.skip_validation) }}
     outputs:
       sync_status: ${{ steps.sync.outcome }}
       source_ref: ${{ steps.source_ref.outputs.ref }}
@@ -116,6 +165,10 @@ jobs:
           
           gh workflow run sync-role-repos.yml \
             --ref main \
+            --field legacy_fallback_ack="${{ inputs.legacy_fallback_ack }}" \
+            --field approval_issue_url="${{ inputs.approval_issue_url }}" \
+            --field approval_comment_url="${{ inputs.approval_comment_url }}" \
+            --field emergency_reason="${{ inputs.emergency_reason }}" \
             --field role="${{ inputs.role_slug }}" \
             --field source_ref="${{ steps.source_ref.outputs.ref }}" \
             $owner_arg \
@@ -219,8 +272,8 @@ jobs:
   publish:
     name: Publish Role Workstation Images
     runs-on: ubuntu-latest
-    needs: [sync, wait-for-sync]
-    if: ${{ !inputs.dry_run && needs.wait-for-sync.outputs.sync_completed == 'true' }}
+    needs: [authorize_fallback, sync, wait-for-sync]
+    if: ${{ needs.authorize_fallback.outputs.approved == 'true' && !inputs.dry_run && needs.wait-for-sync.outputs.sync_completed == 'true' }}
     steps:
       - name: Trigger publish workflow
         env:
@@ -229,7 +282,12 @@ jobs:
           set -euo pipefail
           echo "::group::Triggering publish workflow"
           
-          gh workflow run publish-role-workstation-images.yml --ref main
+          gh workflow run publish-role-workstation-images.yml \
+            --ref main \
+            --field legacy_fallback_ack="${{ inputs.legacy_fallback_ack }}" \
+            --field approval_issue_url="${{ inputs.approval_issue_url }}" \
+            --field approval_comment_url="${{ inputs.approval_comment_url }}" \
+            --field emergency_reason="${{ inputs.emergency_reason }}"
           
           echo "✅ Publish workflow triggered"
           echo "::endgroup::"
@@ -239,7 +297,7 @@ jobs:
   summary:
     name: Onboarding Summary
     runs-on: ubuntu-latest
-    needs: [preflight, sync, wait-for-sync, publish]
+    needs: [authorize_fallback, preflight, sync, wait-for-sync, publish]
     if: always()
     steps:
       - name: Generate summary

--- a/.github/workflows/publish-role-workstation-images.yml
+++ b/.github/workflows/publish-role-workstation-images.yml
@@ -1,21 +1,24 @@
 name: Publish Role Workstation Images
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - .devcontainer-workstation/**
-      - 10-templates/agent-instructions/**
-      - 10-templates/compliance-officer-pr-review-brief.md
-      - .github/workflows/publish-role-workstation-images.yml
-  workflow_run:
-    workflows: ["Sync Role Repositories"]
-    types:
-      - completed
-    branches:
-      - main
   workflow_dispatch:
+    inputs:
+      legacy_fallback_ack:
+        description: Type ALLOW-LEGACY-FALLBACK to authorize emergency legacy publish
+        required: true
+        type: string
+      approval_issue_url:
+        description: Context-Engineering Issue URL approving emergency fallback use
+        required: true
+        type: string
+      approval_comment_url:
+        description: Approval comment URL (Executive Sponsor or delegated approver)
+        required: true
+        type: string
+      emergency_reason:
+        description: Short reason why implementation repo publish path cannot be used
+        required: true
+        type: string
 
 concurrency:
   group: publish-role-workstation-${{ github.ref }}
@@ -26,10 +29,42 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  authorize_fallback:
+    name: Authorize Legacy Fallback
     runs-on: ubuntu-latest
-    # Skip if triggered by workflow_run and sync failed
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      approved: ${{ steps.authorize.outputs.approved }}
+    steps:
+      - name: Validate emergency fallback authorization
+        id: authorize
+        env:
+          ACK: ${{ inputs.legacy_fallback_ack }}
+          ISSUE_URL: ${{ inputs.approval_issue_url }}
+          COMMENT_URL: ${{ inputs.approval_comment_url }}
+          REASON: ${{ inputs.emergency_reason }}
+        run: |
+          set -euo pipefail
+          if [ "$ACK" != "ALLOW-LEGACY-FALLBACK" ]; then
+            echo "::error::Legacy fallback authorization denied. Set legacy_fallback_ack to ALLOW-LEGACY-FALLBACK."
+            exit 1
+          fi
+          if [ -z "$ISSUE_URL" ] || [ -z "$COMMENT_URL" ] || [ -z "$REASON" ]; then
+            echo "::error::approval_issue_url, approval_comment_url, and emergency_reason are required."
+            exit 1
+          fi
+          {
+            echo "### Legacy fallback authorization"
+            echo
+            echo "- Approval issue: \`$ISSUE_URL\`"
+            echo "- Approval comment: \`$COMMENT_URL\`"
+            echo "- Reason: \`$REASON\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "approved=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: [authorize_fallback]
+    if: ${{ needs.authorize_fallback.outputs.approved == 'true' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -111,11 +146,6 @@ jobs:
             echo "Found: $source_ref"
             echo "::notice::Sync workflow for commit $expected_ref may still be running or needs to be triggered."
             echo "::notice::Check sync-role-repos workflow: https://github.com/${{ github.repository }}/actions/workflows/sync-role-repos.yml"
-            
-            # If triggered by workflow_run, this means sync just completed but role repo isn't updated yet
-            if [ "${{ github.event_name }}" =  "workflow_run" ]; then
-              echo "::warning::Sync workflow completed but role repo not yet updated. This may indicate sync PR not yet merged."
-            fi
             
             exit 1
           fi

--- a/.github/workflows/sync-role-repos.yml
+++ b/.github/workflows/sync-role-repos.yml
@@ -1,22 +1,24 @@
 name: Sync Role Repositories
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - governance.md
-      - 00-os/role-charters/**
-      - 10-templates/agent-instructions/**
-      - 10-templates/compliance-officer-pr-review-brief.md
-      - 10-templates/job-description-spec/**
-      - 10-templates/repo-starters/role-repo-template/templates/**
-      - 10-templates/repo-starters/role-repo-template/scripts/build-agent-job-description.py
-      - 10-templates/repo-starters/role-repo-template/scripts/render-role-repo-template.sh
-      - 10-templates/repo-starters/role-repo-template/scripts/sync-role-repo.sh
-      - .github/workflows/sync-role-repos.yml
   workflow_dispatch:
     inputs:
+      legacy_fallback_ack:
+        description: Type ALLOW-LEGACY-FALLBACK to authorize emergency legacy sync
+        required: true
+        type: string
+      approval_issue_url:
+        description: Context-Engineering Issue URL approving emergency fallback use
+        required: true
+        type: string
+      approval_comment_url:
+        description: Approval comment URL (Executive Sponsor or delegated approver)
+        required: true
+        type: string
+      emergency_reason:
+        description: Short reason why implementation repo sync path cannot be used
+        required: true
+        type: string
       role:
         description: Role slug to sync
         required: true
@@ -58,7 +60,41 @@ permissions:
   contents: read
 
 jobs:
+  authorize_fallback:
+    name: Authorize Legacy Fallback
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.authorize.outputs.approved }}
+    steps:
+      - name: Validate emergency fallback authorization
+        id: authorize
+        env:
+          ACK: ${{ inputs.legacy_fallback_ack }}
+          ISSUE_URL: ${{ inputs.approval_issue_url }}
+          COMMENT_URL: ${{ inputs.approval_comment_url }}
+          REASON: ${{ inputs.emergency_reason }}
+        run: |
+          set -euo pipefail
+          if [ "$ACK" != "ALLOW-LEGACY-FALLBACK" ]; then
+            echo "::error::Legacy fallback authorization denied. Set legacy_fallback_ack to ALLOW-LEGACY-FALLBACK."
+            exit 1
+          fi
+          if [ -z "$ISSUE_URL" ] || [ -z "$COMMENT_URL" ] || [ -z "$REASON" ]; then
+            echo "::error::approval_issue_url, approval_comment_url, and emergency_reason are required."
+            exit 1
+          fi
+          {
+            echo "### Legacy fallback authorization"
+            echo
+            echo "- Approval issue: \`$ISSUE_URL\`"
+            echo "- Approval comment: \`$COMMENT_URL\`"
+            echo "- Reason: \`$REASON\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "approved=true" >> "$GITHUB_OUTPUT"
+
   sync:
+    needs: [authorize_fallback]
+    if: ${{ needs.authorize_fallback.outputs.approved == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/00-os/runbooks/split-repository-cutover-and-rollback.md
+++ b/00-os/runbooks/split-repository-cutover-and-rollback.md
@@ -69,6 +69,12 @@ Initiate rollback if any of the following occur post-cutover:
 2. Activate temporary legacy execution path
    - Re-enable mixed-layout execution updates in `Context-Engineering` only for impacted flows.
    - Use legacy `.github/workflows/sync-role-repos.yml` as temporary operational control point.
+   - Legacy execution workflows are emergency/manual only and require workflow dispatch authorization fields:
+     - `legacy_fallback_ack=ALLOW-LEGACY-FALLBACK`
+     - `approval_issue_url` (linked approval issue)
+     - `approval_comment_url` (approval comment evidence)
+     - `emergency_reason` (why split execution path is unavailable)
+   - For orchestrated fallback, dispatch `orchestrate-role-onboarding.yml`, which forwards the same authorization evidence to sync/publish fallback workflows.
 3. Stabilize and validate
    - Confirm role sync can complete using temporary legacy path.
    - Confirm no conflicting governance authority edits are introduced in rollback window.
@@ -86,4 +92,3 @@ Validation mode: tabletop + control-point verification (2026-02-26)
 - Legacy and split sync workflow control points confirmed present.
 - Trigger criteria and owner/approval escalation path documented.
 - Evidence capture requirements defined for incident and closure.
-


### PR DESCRIPTION
## Summary
- convert legacy execution workflows in `Context-Engineering` to emergency/manual-only dispatch
- remove routine automatic triggers from legacy sync/publish workflows
- require explicit authorization evidence for fallback execution (`legacy_fallback_ack`, approval issue/comment URLs, emergency reason)
- update split cutover runbook with required emergency dispatch controls

## Scope
- `.github/workflows/sync-role-repos.yml`
- `.github/workflows/publish-role-workstation-images.yml`
- `.github/workflows/orchestrate-role-onboarding.yml`
- `00-os/runbooks/split-repository-cutover-and-rollback.md`

## Before/After Evidence
Before:
- `sync-role-repos.yml` executed on `push` to `main`
- `publish-role-workstation-images.yml` executed on `push` and `workflow_run`

After:
- all three legacy execution workflows are `workflow_dispatch` only
- all fallback executions require explicit emergency authorization inputs and evidence

## Validation
- `python3` YAML parse of modified workflow files (pass)
- `git diff --check`

## ADR Linkage
- ADR-Required: Yes
- Primary-ADR: 0002-split-context-engineering-into-governance-and-implementation-repos.md
- ADR-Status-At-Merge: Accepted
- ADR-Exception-Evidence: N/A
- ADR-Supersession-Traceability: N/A

Primary-Role: AI Governance Manager
Reviewed-By-Role: N/A
Executive-Sponsor-Approval: Required
Primary-Issue-Ref: Closes #79
Development-Linkage: Verified
Development-Linkage-Evidence: Linked via `Primary-Issue-Ref: Closes #79`; this PR should appear in the issue Development section.
